### PR TITLE
Catch NPEs when preloading an image

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="lib" path="lib/commons-logging-1.1.jar"/>
-	<classpathentry kind="lib" path="lib/jcgm-core-0.3.0.jar"/>
+	<classpathentry kind="lib" path="lib/jcgm-core-2.0.2.jar"/>
 	<classpathentry kind="lib" path="lib/xmlgraphics-commons-1.3.1.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/build.xml
+++ b/build.xml
@@ -7,13 +7,13 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The image package -->
-	<property name="version-image" value="0.1.1"/>
+	<property name="version-image" value="0.1.2"/>
 	<property name="package-name-image" value="jcgm-image-${version-image}"/>
 	<property name="jar-name-image" value="${package-name-image}.jar"/>
 	<property name="package-name-image-bin" value="${package-name-image}-bin"/>
 
 	<!-- The dependent core package -->
-	<property name="jcgm-core" value="jcgm-core-0.3.0.jar"/>
+	<property name="jcgm-core" value="jcgm-core-2.0.2.jar"/>
 
 	<!-- Source code only distributed in one package -->
 	<property name="package-name-src" value="jcgm-src"/>

--- a/src/net/sf/jcgm/image/loader/cgm/PreloaderCGM.java
+++ b/src/net/sf/jcgm/image/loader/cgm/PreloaderCGM.java
@@ -35,6 +35,8 @@ import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.stream.ImageInputStream;
 import javax.xml.transform.Source;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.xmlgraphics.image.loader.ImageContext;
 import org.apache.xmlgraphics.image.loader.ImageException;
 import org.apache.xmlgraphics.image.loader.ImageInfo;
@@ -60,7 +62,9 @@ import org.apache.xmlgraphics.image.loader.util.ImageUtil;
  * @see <a href="http://xmlgraphics.apache.org/">xmlgraphics.apache.org</a>
  */
 public class PreloaderCGM extends AbstractImagePreloader {
-
+	
+	protected static Log log = LogFactory.getLog("net.sf.jcgm.image.loader.cgm.PreloaderCGM");
+	
 	@Override
 	public ImageInfo preloadImage(String originalURI, Source src, ImageContext context)
 			throws ImageException, IOException {
@@ -94,7 +98,10 @@ public class PreloaderCGM extends AbstractImagePreloader {
                 if (firstIOException == null) {
                     firstIOException = ioe;
                 }
-            } finally {
+	        } catch (NullPointerException e) {
+		        log.warn(originalURI + " " + e);
+		        return null;
+	        } finally {
                 reader.dispose();
                 in.reset();
             }


### PR DESCRIPTION
Catch NPEs thrown during image preloading.

Indeed, it can happen that when preloading SVG images we enter the preloading and try to get the width and throw. This breaks the lookup for the correct pre-loader.

Release version upgraded to 0.1.2.