### PR TITLE
Feature/diaa/new system prop to turn on logs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 <project name="jcgm" default="jar">
 	
 	<!-- The image package -->
-	<property name="version-image" value="0.2.1"/>
+	<property name="version-image" value="0.2.2"/>
 	<property name="package-name-image" value="jcgm-image-${version-image}"/>
 	<property name="jar-name-image" value="${package-name-image}.jar"/>
 	<property name="package-name-image-bin" value="${package-name-image}-bin"/>

--- a/src/net/sf/jcgm/image/loader/cgm/ImageLoaderCGM.java
+++ b/src/net/sf/jcgm/image/loader/cgm/ImageLoaderCGM.java
@@ -67,6 +67,7 @@ public class ImageLoaderCGM extends AbstractImageLoader {
 	
     /** logging instance */
     protected static Log log = LogFactory.getLog("net.sf.jcgm.image.loader.cgm.ImageLoaderCGM");
+	private boolean isDebugMode = false;
 	
 	private final ImageFlavor targetFlavor;
 
@@ -76,6 +77,11 @@ public class ImageLoaderCGM extends AbstractImageLoader {
             throw new IllegalArgumentException("Unsupported target ImageFlavor: " + targetFlavor);
 		}
 		
+		loadSystemProperties();
+	}
+
+	private void loadSystemProperties() {
+		this.isDebugMode =  Boolean.getBoolean("net.sf.jcgm.image.loader.cgm.debugmode");
 	}
 
 	@Override
@@ -107,8 +113,10 @@ public class ImageLoaderCGM extends AbstractImageLoader {
 		final CGMDisplay display = new CGMDisplay(cgm);
 		
 		// publish the error messages to the logger
-		for (Message m: cgm.getMessages()) {
-			log.warn(info.getOriginalURI()+ " " + m);
+		if (this.isDebugMode) {
+			for (Message m: cgm.getMessages()) {
+				log.warn(info.getOriginalURI()+ " " + m);
+			}
 		}
 		
 		return new ImageGraphics2D(info, new Graphics2DImagePainter() {


### PR DESCRIPTION
The logger can be pretty verbose: e.g. when a command is not implemented (there are many) or unsupported etc. messages are printed when loading an image.

I added a new system property to turn on the "debug mode", which currently only affects the printing of logs when loading an image. Default behaviour is now that messages are not printed.